### PR TITLE
Add latvian, Portuguese and Greek as available locales

### DIFF
--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -6,7 +6,7 @@ Decidim.configure do |config|
 
   # Change these lines to set your preferred locales
   config.default_locale = :en
-  config.available_locales = [:en, :ca, :es, :nl]
+  config.available_locales = [:en, :ca, :es, :nl, :lv, :el, :pt]
 
   # Geocoder configuration
   config.maps = {


### PR DESCRIPTION
This PR adds latvian, portuguese and greek as available locales for the different organizations.